### PR TITLE
Fix taking screenshot after error

### DIFF
--- a/support/utils/Utilities.js
+++ b/support/utils/Utilities.js
@@ -7,22 +7,17 @@ class Utilities {
 
   static takeScreenshot(name, failure=false) {
     const path = './report/screenshot/';
-    fs.access(path, fs.F_OK, (err) => {
-      if (err) {
-        console.info('File path doesn\'t exists ... Let\'s create!');
-        fs.mkdir(path, { recursive: true }, (err) => {});
-      }
-      // file exists
-    });
+    if (!fs.existsSync(path)) {
+      fs.mkdirSync(path, { recursive: true });
+    }
+
     if (failure) {
       name = name + '_fail';
     }
     name = name.replace(/ /g, '_') + '.png';
-    browser.pause(500);
     browser.saveScreenshot( path + name);
-    fs.readFile(`${path}/${name}`, function(err, data) {
-      allure.addAttachment(name, data, 'image/png');
-    });
+    const data = fs.readFileSync(`${path}/${name}`);
+    allure.addAttachment(name, data, 'image/png');
   }
 }
 


### PR DESCRIPTION
It need to be done synchronously, otherwise Allure will close current case and then silently fail to save attachment.